### PR TITLE
chore(travis): add Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: rust
+rust:
+- stable
+before_script:
+- pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+script:
+- travis-cargo build
+- travis-cargo test
+- travis-cargo doc

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ via fcntl().
 
 # SUPPORT
 
+[![Build Status](https://travis-ci.org/alfiedotwtf/file-lock.svg?branch=idiomatic-rust)](https://travis-ci.org/alfiedotwtf/file-lock)
+
 Please report any bugs or feature requests at:
 
 * [https://github.com/alfiedotwtf/file-lock/issues](https://github.com/alfiedotwtf/file-lock/issues)


### PR DESCRIPTION
To make this work, the github-project needs to enable the travis
hook in the settings.

PS: Please let me know if I may proceed using the [angular.js](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines) commit style. I like it for many reasons, and the usability of [clog](http://blog.thoughtram.io/announcements/tools/2014/09/18/announcing-clog-a-conventional-changelog-generator-for-the-rest-of-us.html) is just one of them.