### PR TITLE
fix(lock): avoid file handle leakage

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -33,6 +33,7 @@ struct result lock_type(const char* pathname) { \
   if (fcntl(fd, cmd, &fl) == -1) {              \
     my_result.fd    = -1;                       \
     my_result.error = errno;                    \
+    close(fd);                                  \
     return my_result;                           \
   }                                             \
                                                 \


### PR DESCRIPTION
Previously, the descriptor to an opened file was not closed if
the call the `fcntl(...)` failed.
We don't check or report the possible error on the
inserted `close()` call, as our space for errno is already occupied
by the result of `fcntl`.