### PR TITLE
refactor(lib): made code more idiomatic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,9 @@ macro_rules! _create_lock_type {
             Ok(raw_filename) => {
                 let my_result = unsafe { $c_lock_type(raw_filename.as_ptr()) };
 
-                return match my_result._fd {
-                  -1 => Err(Error::Errno(my_result._errno)),
-                   _ => Ok(Lock{_fd: my_result._fd}),
+                return match my_result._errno {
+                   0 => Ok(Lock{_fd: my_result._fd}),
+                   _ => Err(Error::Errno(my_result._errno)),
                 }
             }
         }
@@ -135,9 +135,9 @@ pub fn unlock(lock: &Lock) -> Result<bool, Error> {
   unsafe {
     let my_result = c_unlock(lock._fd);
 
-    return match my_result._fd {
-      -1 => Err(Error::Errno(my_result._errno)),
-       _ => Ok(true),
+    return match my_result._errno {
+       0 => Ok(true),
+       _ => Err(Error::Errno(my_result._errno)),
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,12 +131,12 @@ extern {
 ///     }
 /// }
 /// ```
-pub fn unlock(lock: &Lock) -> Result<bool, Error> {
+pub fn unlock(lock: &Lock) -> Result<(), Error> {
   unsafe {
     let my_result = c_unlock(lock._fd);
 
     return match my_result._errno {
-       0 => Ok(true),
+       0 => Ok(()),
        _ => Err(Error::Errno(my_result._errno)),
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,15 @@ extern crate libc;
 use std::ffi::CString;
 
 /// Represents a lock on a file.
+#[derive(Debug, Eq, PartialEq)]
 pub struct Lock {
   _fd: i32,
 }
 
-/// Represents the error that occured while trying to lock or unlock a file.
+/// Represents the error that occurred while trying to lock or unlock a file.
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
-  /// caused when the filename is invalid as it contains a nul byte.
+  /// caused when the filename is invalid as it contains a null byte.
   InvalidFilename,
   /// caused when the error occurred at the filesystem layer (see
   /// [errno](https://crates.io/crates/errno)).
@@ -125,7 +127,7 @@ extern {
 /// use file_lock::*;
 ///
 /// fn main() {
-///     let l = lock("/tmp/file-lock-test").ok().unwrap();
+///     let l = lock("/tmp/file-lock-test").unwrap();
 ///
 ///     if unlock(&l).is_ok() {
 ///         println!("Unlocked!");
@@ -152,6 +154,8 @@ impl Drop for Lock {
 
 #[cfg(test)]
 mod test {
+    use libc;
+    
     use super::*;
     use super::Error::*;
 
@@ -164,80 +168,57 @@ mod test {
 
     #[test]
     fn lock_invalid_filename() {
-        assert_eq!(_lock("null\0inside"), "invalid");
+        assert_eq!(lock("null\0inside"), Err(Error::InvalidFilename));
     }
 
     #[test]
     fn lock_errno() {
-        assert_eq!(_lock(""), "errno");
+        assert_eq!(lock(""), Err(Error::Errno(libc::consts::os::posix88::ENOENT)));
     }
 
     #[test]
     fn lock_ok() {
-        assert_eq!(_lock("/tmp/file-lock-test"), "ok");
-    }
-
-    fn _lock(filename: &str) -> &str {
-        let l = lock(filename);
-
-        match l {
-            Ok(_)  => "ok",
-            Err(e) => match e {
-                InvalidFilename => "invalid",
-                Errno(_)        => "errno",
-            }
-        }
+        assert!(lock("/tmp/file-lock-test").is_ok());
     }
 
     // lock_wait() tests
 
     #[test]
     fn lock_wait_invalid_filename() {
-        assert_eq!(_lock_wait("null\0inside"), "invalid");
+        assert_eq!(lock_wait("null\0inside"), Err(Error::InvalidFilename));
     }
 
     #[test]
     fn lock_wait_errno() {
-        assert_eq!(_lock_wait(""), "errno");
+        assert_eq!(lock_wait(""), Err(Error::Errno(libc::consts::os::posix88::ENOENT)));
     }
 
     #[test]
     fn lock_wait_ok() {
-        assert_eq!(_lock_wait("/tmp/file-lock-test"), "ok");
-    }
-
-    fn _lock_wait(filename: &str) -> &str {
-        let l = lock_wait(filename);
-
-        match l {
-            Ok(_)  => "ok",
-            Err(e) => match e {
-                InvalidFilename => "invalid",
-                Errno(_)        => "errno",
-            }
-        }
+        assert!(lock_wait("/tmp/file-lock-test").is_ok());
     }
 
     // unlock()
 
-    //
+    
     // fcntl() will only allow us to hold a single lock on a file at a time
     // so this test can't work :(
-    //
-    // #[test]
-    // fn unlock_error() {
-    //     let l1 = lock("/tmp/file-lock-test");
-    //     let l2 = lock("/tmp/file-lock-test");
-    //
-    //     assert!(l1.is_ok());
-    //     assert!(l2.is_err());
-    // }
-    //
+    
+    #[test]
+    #[should_panic]
+    fn unlock_error() {
+        let l1 = lock("/tmp/file-lock-test");
+        let l2 = lock("/tmp/file-lock-test");
+    
+        assert!(l1.is_ok());
+        assert!(l2.is_err());
+    }
+    
 
     #[test]
     fn unlock_ok() {
         let l        = lock_wait("/tmp/file-lock-test");
-        let unlocked = l.ok().unwrap();
+        let unlocked = l.unwrap();
 
         assert!(unlock(&unlocked).is_ok(), true);
     }

--- a/src/lock.c
+++ b/src/lock.c
@@ -53,7 +53,7 @@ struct result c_unlock(int fd) {
     return my_result;
   }
 
-  my_result.fd    = 0;
+  my_result.fd    = -1;
   my_result.error = 0;
   return my_result;
 }


### PR DESCRIPTION
* add some traits to simplify usage and testing of custom types, namely
  `Debug`, `PartialEq` and `Eq`
* replace `ok().unwrap()` with `unwrap()` to not degenerate errors
* compare against expected exact values, instead of strings.
* remove now unused code
* mark tests that panic as `should_panic`