### PR TITLE
Update nix to 0.24.1, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ readme        = "README.md"
 build   = "build.rs"
 
 [dependencies]
-libc   = "=0.2.112"
+libc   = "=0.2.121"
 mktemp = "=0.4.1"
-nix    = "=0.23.1"
+nix    = { version = "=0.24.1", default-features = false, features = ["process"] }
 
 [build-dependencies]
 cc = "=1.0.72"


### PR DESCRIPTION
This reduces the total clean build time by about half, because nix is in the critical path.