### PR TITLE
Lock for read only and write only if read cleared after write set

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Feel free to fork the repository and submit pull requests :)
 
 Corey Richardson
 
+Ed Branch
+
 Jacob Turner
 
 Mateusz Kondej

--- a/src/file_options.rs
+++ b/src/file_options.rs
@@ -42,7 +42,6 @@ impl FileOptions {
 
     pub fn read(mut self, read: bool) -> Self {
         self.open_options.read(read);
-        self.writeable = read;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,4 +316,14 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn lock_for_read_or_write_only() -> std::io::Result<()> {
+        let filename = "lock_for_read_only.test";
+        std::fs::write(filename, format!("Just at test\n"))?;
+        let lock = FileLock::lock(filename, false, FileOptions::new().read(true))?;
+        lock.unlock()?;
+        FileLock::lock(filename, false, FileOptions::new().write(true).read(false))?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Calling `FileOptions::read(true)` currently sets `writeable`, which causes `FileLock::lock()` to fail with `EBADF` if the file is not being opened for write. Also, if read(false) is called *after* write(true), the read(false) call will **clear** `writeable` even though the file is will be opened for writing. This also results in `EBADF`.

This PR adds a test for both of the above conditions, then fixes that test by simply not modifying `writeable` in `FileOptions::read()`.